### PR TITLE
Fix extra json escaping

### DIFF
--- a/src/md4w.zig
+++ b/src/md4w.zig
@@ -529,7 +529,7 @@ const JOSNRenderer = struct {
                 if (code.lang.size > 0) {
                     w.writeJSONProps();
                     w.write("\"lang\":\"");
-                    w.writeJSONString(@as([*]const u8, @ptrCast(code.lang.text))[0..code.lang.size], 1);
+                    w.writeJSONString(@as([*]const u8, @ptrCast(code.lang.text))[0..code.lang.size], 0);
                     w.write("\"}");
                 }
                 w.writeJSONChildren();
@@ -600,7 +600,7 @@ const JOSNRenderer = struct {
                 w.writeJSONString(@as([*]const u8, @ptrCast(a.href.text))[0..a.href.size], 2);
                 if (a.title.size > 0) {
                     w.write("\",\"title\":");
-                    w.writeJSONString(@as([*]const u8, @ptrCast(a.title.text))[0..a.title.size], 1);
+                    w.writeJSONString(@as([*]const u8, @ptrCast(a.title.text))[0..a.title.size], 0);
                 }
                 w.write("\"}");
                 w.writeJSONChildren();
@@ -610,7 +610,7 @@ const JOSNRenderer = struct {
                 w.writeJSONType(30 + typ);
                 w.writeJSONProps();
                 w.write("\"src\":\"");
-                w.writeJSONString(@as([*]const u8, @ptrCast(img.src.text))[0..img.src.size], 2);
+                w.writeJSONString(@as([*]const u8, @ptrCast(img.src.text))[0..img.src.size], 0);
                 w.write("\",\"alt\":"); // alt text will be added in the text callback
             },
             c.MD_SPAN_WIKILINK => {
@@ -647,7 +647,7 @@ const JOSNRenderer = struct {
             }
             if (img.title.size > 0) {
                 w.write("\"title\":\"");
-                w.writeJSONString(@as([*]const u8, @ptrCast(img.title.text))[0..img.title.size], 1);
+                w.writeJSONString(@as([*]const u8, @ptrCast(img.title.text))[0..img.title.size], 0);
                 w.write("\"");
             }
             w.write("}},");
@@ -701,9 +701,8 @@ const JOSNRenderer = struct {
                 }
             },
             else => {
-                const escape: u2 = if (typ == c.MD_TEXT_CODE) 0 else 1;
                 w.writeByte('"');
-                w.writeJSONString(@as([*]const u8, @ptrCast(ptr))[0..len], escape);
+                w.writeJSONString(@as([*]const u8, @ptrCast(ptr))[0..len], 0);
                 w.write("\",");
             },
         }

--- a/src/md4w.zig
+++ b/src/md4w.zig
@@ -610,7 +610,7 @@ const JOSNRenderer = struct {
                 w.writeJSONType(30 + typ);
                 w.writeJSONProps();
                 w.write("\"src\":\"");
-                w.writeJSONString(@as([*]const u8, @ptrCast(img.src.text))[0..img.src.size], 0);
+                w.writeJSONString(@as([*]const u8, @ptrCast(img.src.text))[0..img.src.size], 2);
                 w.write("\",\"alt\":"); // alt text will be added in the text callback
             },
             c.MD_SPAN_WIKILINK => {

--- a/test/test.js
+++ b/test/test.js
@@ -15,10 +15,10 @@ await init();
 
 Deno.test("render to string", async (t) => {
   await t.step("commonmark-spec", async () => {
-    const md = await Deno.readFile(
+    const specMd = await Deno.readFile(
       new URL("commonmark-spec.md", import.meta.url),
     );
-    const html = mdToHtml(md);
+    const html = mdToHtml(specMd);
     assertIncludes(html, "<h1>Introduction"); // main heading
     assertIncludes(html, '<ol start="2"');
     assertIncludes(html, "<p>After we're done"); // last paragraph
@@ -149,7 +149,7 @@ Deno.test("using code hightlighter", async () => {
 });
 
 Deno.test("render to json", async () => {
-  const md = `
+  const simpleMd = `
 # Jobs
 Stay _foolish_, stay **hungry**!
 
@@ -185,9 +185,11 @@ console.log('Hello, world!');
 | :--- | ---: |
 | \`git status\` | List all *new or modified* files |
 | \`git diff\` | Show file differences that **haven't been** staged |
+
+This is hardly a "corner case," for some reason.
 `;
 
-  const tree = mdToJSON(md);
+  const tree = mdToJSON(simpleMd);
   assertEquals(tree, {
     children: [
       { type: NodeType.H1, children: ["Jobs"] },
@@ -467,6 +469,18 @@ console.log('Hello, world!');
           },
         ],
       },
+      {
+        type: NodeType.P,
+        children: [
+          "This is hardly a \"corner case,\" for some reason.",
+        ],
+      }
     ],
   });
+
+  // Make sure spec can be parsed
+  // const specMd = await Deno.readFile(
+  //   new URL("commonmark-spec.md", import.meta.url),
+  // );
+  // mdToJSON(specMd);
 });


### PR DESCRIPTION
Resolves #5

I checked the impl and it seems `safeWriteChar` for escaping `<>&"` is only necessary for HTML output and not JSON one.

This PR fixes it by changing all usages of `writeJSONString` within `JOSNRenderer` to unescaped (my guess even for attrs it might be unnecessary but haven't touched it)

Also added small changes in test to cover regression + ~~only make sure JSON renderer can pass the commonmark parsing.~~ (TODO, still failing) 